### PR TITLE
Use rebabel as a Python library on frontend

### DIFF
--- a/rebabel_scripts/README.md
+++ b/rebabel_scripts/README.md
@@ -1,0 +1,10 @@
+### Steps to create the single file executable from rebabel_convert.py using PyInstaller
+1. `cd rebabel_scripts` 
+2. Create and activate Python [virtual environment](https://docs.python.org/3/library/venv.html). 
+    - macOS commands
+        - `python3 -m venv .venv`
+        - `source .venv/bin/activate`
+3. Run `pip install -r requirements.txt`
+4. Run `pyinstaller --onefile --collect-all rebabel_format rebabel_convert.py`
+5. The executable will be located in the 'dist' folder that is generated. The JavaScript looks for the executable in the top level of the 'rebabel_scripts' directory, so move the executable one directory up.
+6. The executable will run by clicking the 'Convert' button on the user interface after running `npm run start`.

--- a/rebabel_scripts/rebabel_convert.py
+++ b/rebabel_scripts/rebabel_convert.py
@@ -1,0 +1,29 @@
+import json
+import sys
+import rebabel_format
+
+script_name, import_mode, output_mode, delimiter, infile, mappings = sys.argv
+mappings = json.loads(mappings)
+
+rebabel_format.load_processes(True)
+rebabel_format.load_readers(True)
+rebabel_format.load_writers(True)
+rebabel_format.get_process_parameters("export")
+
+rebabel_format.run_command(
+    "import",
+    mode=import_mode,
+    db="temp.db",
+    infiles=[infile],
+    delimiter=delimiter
+)
+
+rebabel_format.run_command(
+    "export",
+    mode=output_mode,
+    db="temp.db",
+    outfile="out.flextext",
+    mappings=mappings["mappings"],
+    root="phrase",
+    skip=["morph"],
+)

--- a/rebabel_scripts/requirements.txt
+++ b/rebabel_scripts/requirements.txt
@@ -1,0 +1,2 @@
+pyinstaller==6.10.0
+rebabel_format @ git+https://github.com/ElizabethThorner/Gap-App.git

--- a/src/Components/App.jsx
+++ b/src/Components/App.jsx
@@ -6,6 +6,11 @@ function App() {
     const response = await window.pythonApi.actions(command);
     setText(() => response);
   }
+
+  async function rebabel() {
+    const response = await window.pythonApi.rebabelConvert();
+  }
+
   return (
     <div>
       <h1>Gap App</h1>
@@ -17,6 +22,9 @@ function App() {
       </button>
       <button id="exportBtn" onClick={() => action("export")}>
         Export
+      </button>
+      <button id="convertBtn" onClick={() => rebabel()}>
+        Convert
       </button>
       <div>
         <h2>Output:</h2>

--- a/src/preload.js
+++ b/src/preload.js
@@ -2,4 +2,5 @@ const { contextBridge, ipcRenderer } = require("electron");
 
 contextBridge.exposeInMainWorld("pythonApi", {
   actions: (data) => ipcRenderer.invoke("action", [data]),
+  rebabelConvert: () => ipcRenderer.invoke('rebabelConvert').then(conversionFailure => conversionFailure)
 });


### PR DESCRIPTION
I added a 'Convert' button to the user interface. Clicking this button leads to an executable being called that imports the nlp_pos.txt file and exports the language data in flextext format. The executable is created from a Python script that imports the rebabel_format module. This is the first step in transitioning the backend from using the rebabel_format command-line tool to using rebabel_format as a Python library. 

I've consolidated all Python related files in their own folder(rebabel_scripts). I've also included instructions for generating the executable from rebabel_convert.py in the README.md.