### PR TITLE
fix different paths issue + fix windows pipeline

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -1,10 +1,11 @@
 const { FusesPlugin } = require('@electron-forge/plugin-fuses');
 const { FuseV1Options, FuseVersion } = require('@electron/fuses');
+const isWindows = process.platform === 'win32';
 
 module.exports = {
   packagerConfig: {
     asar: true,
-    extraResource: ["./rebabel_scripts/rebabel_convert"]
+    extraResource: [isWindows ? "./rebabel_scripts/rebabel_convert.exe" : "./rebabel_scripts/rebabel_convert"]
   },
   rebuildConfig: {},
   makers: [

--- a/src/main.js
+++ b/src/main.js
@@ -194,8 +194,16 @@ app.whenReady().then(() => {
     } = data;
 
     // The arguments passed to execFile are hardcoded. They will be passed from the frontend once forms are present to receive input from the user.
-    const rebabelConvertPath = path.join(process.resourcesPath, 'rebabel_convert');
-    const tempdbPath = path.join(process.resourcesPath, 'temp.db');
+    //const rebabelConvertPath = path.join(process.resourcesPath, 'rebabel_convert');
+    //const tempdbPath = path.join(process.resourcesPath, 'temp.db');
+
+    rebabelConvertPath = 'resources/rebabel_convert';
+    tempdbPath = 'resources/temp.db';
+    if (!app.isPackaged) {
+      rebabelConvertPath = 'rebabel_scripts/rebabel_convert';
+      tempdbPath = 'temp.db';
+    }
+    console.log(rebabelConvertPath);
 
     const { stdout, stderr } = await execFilePromisified(
       rebabelConvertPath,

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,8 @@ const execFilePromisified = util.promisify(
   require("node:child_process").execFile
 );
 
+const isDev = !app.isPackaged;
+
 const FileExtensions = {
   flextext: ".flextext",
   conllu: ".conllu",
@@ -199,7 +201,7 @@ app.whenReady().then(() => {
 
     rebabelConvertPath = 'resources/rebabel_convert';
     tempdbPath = 'resources/temp.db';
-    if (!app.isPackaged) {
+    if (isDev) {
       rebabelConvertPath = 'rebabel_scripts/rebabel_convert';
       tempdbPath = 'temp.db';
     }


### PR DESCRIPTION
npm run start: 
- rebabel path is set to 'rebabel_scripts/rebabel_convert'
- db path is set to 'temp.db'

npm run make:
- rebabel path is set to 'resources/rebabel_convert'
- db path is set to 'resources/temp.db'

added check in forge.config.js that adds .exe extension to rebabel_convert if on windows